### PR TITLE
fix: uv shim was not falling back to vim.loop

### DIFF
--- a/lua/lazy/init.lua
+++ b/lua/lazy/init.lua
@@ -2,7 +2,7 @@
 local M = {}
 M._start = 0
 
-vim.uv = vim.uv or vim.uv
+vim.uv = vim.uv or vim.loop
 
 local function profile_require()
   local done = {} ---@type table<string, true>


### PR DESCRIPTION
The shim was incorrectly set to itself as a fallback, instead of loop.